### PR TITLE
OnMixpanelUpdatesReceivedListener should be public to use it outside of ...

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/OnMixpanelUpdatesReceivedListener.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/OnMixpanelUpdatesReceivedListener.java
@@ -3,7 +3,7 @@ package com.mixpanel.android.mpmetrics;
 /**
  * For use with {@link MixpanelAPI.People#addOnMixpanelUpdatesReceivedListener(OnMixpanelUpdatesReceivedListener)}
  */
-/* package */ interface OnMixpanelUpdatesReceivedListener {
+public interface OnMixpanelUpdatesReceivedListener {
     /**
      * Called when the Mixpanel library has updates, for example, Surveys or Notifications.
      * This method will not be called once per update, but rather any time a batch of updates


### PR DESCRIPTION
...the sdk
